### PR TITLE
Fix bug causing multiple navigation buttons

### DIFF
--- a/src/main/java/com/speaax/DelveCalculatorPlugin.java
+++ b/src/main/java/com/speaax/DelveCalculatorPlugin.java
@@ -128,13 +128,16 @@ public class DelveCalculatorPlugin extends Plugin
 		if (sessionTimeoutTimer != null) {
 			sessionTimeoutTimer.stop();
 		}
-		SwingUtilities.invokeLater(() -> {
-			if (navButton != null) {
-				clientToolbar.removeNavigation(navButton);
-			}
-		});
-		navButton = null;
-		panel = null;
+		
+		if (navButton != null) {
+			clientToolbar.removeNavigation(navButton);
+			navButton = null;
+		}
+		
+		if (panel != null) {
+			panel = null;
+		}
+		
 		lastRegionEntryTime = null;
 	}
 


### PR DESCRIPTION
When turning the plugin off, the panel button wouldn't be removed. If you cycle the plugin on and off, you'd have multiple panel buttons for the plugin. This was caused by the `navButton` being null whenever the `invokeLater` task actually ends up executing. The `ClientToolbar` class already handles the `invokeLater` threading internally, so I just removed it.